### PR TITLE
feat: configure backend as Cloud Storage

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,3 +23,60 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
     "zh:f9b18d0443487e30e0f3b83e311f17c85d184dc9f55b3f9b31332e815c41745a",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.12.0"
+  hashes = [
+    "h1:rvZHMkoxkHrBYQXb/waoZiD2oo3FS1AF8HoWHlb6SN8=",
+    "zh:14701aa307a832d99f567b8056a4c5e4ee5a403d984c98f024deee7507a3f29c",
+    "zh:344eca00ffb2643c2fa7f52f069b659d50bb4c9369df4cad96ea0fadb54282c8",
+    "zh:5fb57c0acfd4d30a39941900040d5518a909d8c975af0c4366a7bfd0d0bb09a8",
+    "zh:617a77048a5b9aa568e8bc706cc84307a237b2dd0e49709028b283f8bbe42475",
+    "zh:677837a05fefe0342cf4d4bdc494e8fd4d62331cac947820e73df37e8f512688",
+    "zh:7b79f6e02474eef4a1480fc6589afb63ed16b25bf019b6056f9838e2845e2ef8",
+    "zh:7d891fceb5b15e81240d829f42e1a36e4c812bfc1abe7856756e59101932205f",
+    "zh:97f1e0ac799faf382426e070e888fac36b0867597b460dc95b0e7f657de21ba9",
+    "zh:9855f2f2f5919ff6a6a2c982439c910d28c8978ad18cd8f549a5d1ba9b4dc4c3",
+    "zh:ac551367180eb396af2a50244e80243d333d600a76002e29935262d76a02290b",
+    "zh:c354f34e6579933d21a98ce7f31f4ef8aeaceb04cfaedaff6d3f3c0be56b2c79",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:JlMZD6nYqJ8sSrFfEAH0Vk/SL8WLZRmFaMUF9PJK5wM=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "gcs" {
+    bucket = "ojiverse-domain-tfstate-be7f8ef4ab37962c"
+  }
+}

--- a/memo.md
+++ b/memo.md
@@ -21,30 +21,17 @@ Then, link the billing account on Web console befor enabling services.
 $ gcloud services enable storage.googleapis.com
 ```
 
-3. Create a service account to manage Google Cloud Storage Bucket
-
-```bash
-$ gcloudgcloud iam service-accounts create tfstate-manager \
-  --description="manage the tfstate for Cloudflare DNS Records IaC" \
-  --display-name="tfstate manager"
-```
-
-Then, binding the pre-defined IAM Polocy to the new service account.
-
-```bash
-gcloud projects add-iam-policy-binding ojiverse \
-  --member="serviceAccount:tfstate-manager@ojiverse.iam.gserviceaccount.com" \
-  --role="roles/storage.admin"
-```
-
-`storage/admin` is too strong policy just to manage tfstatus on the bucket. So I MUST update the policy later.
-
-4. Create a new bucket via Terraform
+3. Create a new bucket via Terraform
 
 Please check [./storage.tf](./storage.tf)
 
-5. migrate the current status with Storage bucket
+NOTE: if you fail to apply the terraform code, you have to complete [the setup of ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc?hl=ja). And ensure the account (or service account) has been grant the permission to manage Cloud Storage Bucket.
+
+4. migrate the current status with Storage bucket
 
 ```bash
 $ terraform init -migrate-state
 ```
+
+Now your tfstate is managed on Cloud Storage.
+

--- a/memo.md
+++ b/memo.md
@@ -1,0 +1,50 @@
+# working memo
+
+## setup Google Cloud Storage for Terraform
+
+ref: https://cloud.google.com/docs/terraform/resource-management/store-state
+
+1. create a new project
+
+```bash
+$ gcloud projects create ojiverse
+```
+
+Project name: `ojiverse`
+Project number: 56226728303
+
+Then, link the billing account on Web console befor enabling services.
+
+2. Enable services
+
+```bash
+$ gcloud services enable storage.googleapis.com
+```
+
+3. Create a service account to manage Google Cloud Storage Bucket
+
+```bash
+$ gcloudgcloud iam service-accounts create tfstate-manager \
+  --description="manage the tfstate for Cloudflare DNS Records IaC" \
+  --display-name="tfstate manager"
+```
+
+Then, binding the pre-defined IAM Polocy to the new service account.
+
+```bash
+gcloud projects add-iam-policy-binding ojiverse \
+  --member="serviceAccount:tfstate-manager@ojiverse.iam.gserviceaccount.com" \
+  --role="roles/storage.admin"
+```
+
+`storage/admin` is too strong policy just to manage tfstatus on the bucket. So I MUST update the policy later.
+
+4. Create a new bucket via Terraform
+
+Please check [./storage.tf](./storage.tf)
+
+5. migrate the current status with Storage bucket
+
+```bash
+$ terraform init -migrate-state
+```

--- a/storage.tf
+++ b/storage.tf
@@ -1,0 +1,33 @@
+resource "random_id" "default" {
+  byte_length = 8
+}
+
+resource "google_storage_bucket" "default" {
+  project = "ojiverse"
+  name     = "ojiverse-domain-tfstate-${random_id.default.hex}"
+  location = "US"
+
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "local_file" "default" {
+  file_permission = "0644"
+  filename        = "${path.module}/backend.tf"
+
+  # You can store the template in a file and use the templatefile function for
+  # more modularity, if you prefer, instead of storing the template inline as
+  # we do here.
+  content = <<-EOT
+  terraform {
+    backend "gcs" {
+      bucket = "${google_storage_bucket.default.name}"
+    }
+  }
+  EOT
+}


### PR DESCRIPTION
This is the preparation for managing Cloudflare DNS records via GitHub.

I will set up GitHub Action to apply the new terraform code from PRs.